### PR TITLE
Security, Bugs, Expense Member Breakdown, Database Change

### DIFF
--- a/app/components/modules/ToadCount.tsx
+++ b/app/components/modules/ToadCount.tsx
@@ -6,6 +6,7 @@ import { type DocumentSnapshot } from "firebase/firestore";
 import { dbDeleteTrip, dbInviteUser, DbNoUserFoundError } from "~/src/databaseUtil";
 import { debugLogComponentRerender, debugLogError } from "~/src/debugUtil";
 import type { TripMembersInfo } from "../pages/TripPageLayout";
+import { useTripPageLayoutContext, type TripPageLayoutContext } from "../pages/TripPageLayout";
 
 export default function ToadCount(props: { tripDbDoc: DocumentSnapshot | null, tripMembersInfo: TripMembersInfo }) {
 
@@ -18,13 +19,21 @@ export default function ToadCount(props: { tripDbDoc: DocumentSnapshot | null, t
             const memberInfo = props.tripMembersInfo[memberEmailId];
 
             return (
-                <ToadMember key={memberInfo.dbDoc.id} memberColor={memberInfo.color} tripDbDoc={props.tripDbDoc} memberDbDoc={memberInfo.dbDoc} />
+                <ToadMember key={memberInfo.dbDoc.id} memberColor={memberInfo.color} tripDbDoc={props.tripDbDoc} memberDbDoc={memberInfo.dbDoc} isTripOwner={isTripOwner}/>
             );
         });
     }
 
     const [email, setEmail] = useState<string>("");
     const [inviteError, setInviteError] = useState<string | null>(null);
+
+
+    const tripPageLayoutContext: TripPageLayoutContext = useTripPageLayoutContext();
+    const currUser: string = tripPageLayoutContext.userDbDoc.get("email");
+    let isTripOwner:boolean = true;
+    if(tripPageLayoutContext.tripDbDoc.get("trip_owner") !== currUser) {
+        isTripOwner = false;
+    }
 
     async function handleInviteSubmit() {
 
@@ -99,14 +108,14 @@ export default function ToadCount(props: { tripDbDoc: DocumentSnapshot | null, t
             </div>
 
             {/* Delete Trip Button */}
-            <div className="mt-2 flex flex-col">
+            {isTripOwner && (<div className="mt-2 flex flex-col">
                 <button
                     onClick={() => handleDeleteTrip(props.tripDbDoc)}
                     className="w-[271px] h-[46px] bg-[#D86D6D]/50 text-white rounded-lg text-sm hover:bg-[#D86D6D]/70 text-center"
                 >
                     Delete Trip
                 </button>
-            </div>
+            </div>)}
         </div>
     );
 }

--- a/app/components/modules/ToadCount.tsx
+++ b/app/components/modules/ToadCount.tsx
@@ -14,21 +14,24 @@ export default function ToadCount(props: { tripDbDoc: DocumentSnapshot | null, t
 
     const navigate = useNavigate();
 
+    const tripPageLayoutContext: TripPageLayoutContext = useTripPageLayoutContext();
+    const trip_active_users: string[] = tripPageLayoutContext.tripDbDoc.get("trip_active_users");
+
     function turnListOfTripsMembersIntoElems(): ReactNode {
         return Object.keys(props.tripMembersInfo).map((memberEmailId) => {
             const memberInfo = props.tripMembersInfo[memberEmailId];
 
-            return (
-                <ToadMember key={memberInfo.dbDoc.id} memberColor={memberInfo.color} tripDbDoc={props.tripDbDoc} memberDbDoc={memberInfo.dbDoc} isTripOwner={isTripOwner}/>
-            );
+            if(trip_active_users.includes(memberInfo.dbDoc.get("email"))) {
+                return (
+                    <ToadMember key={memberInfo.dbDoc.id} memberColor={memberInfo.color} tripDbDoc={props.tripDbDoc} memberDbDoc={memberInfo.dbDoc} isTripOwner={isTripOwner}/>
+                );
+            }
         });
     }
 
     const [email, setEmail] = useState<string>("");
     const [inviteError, setInviteError] = useState<string | null>(null);
 
-
-    const tripPageLayoutContext: TripPageLayoutContext = useTripPageLayoutContext();
     const currUser: string = tripPageLayoutContext.userDbDoc.get("email");
     let isTripOwner:boolean = true;
     if(tripPageLayoutContext.tripDbDoc.get("trip_owner") !== currUser) {
@@ -65,7 +68,7 @@ export default function ToadCount(props: { tripDbDoc: DocumentSnapshot | null, t
     }
 
     const toadCount: string = props.tripDbDoc !== null
-        ? props.tripDbDoc.get("trip_users").length
+        ? props.tripDbDoc.get("trip_active_users").length
         : "?"
         ;
 

--- a/app/components/modules/ToadCount.tsx
+++ b/app/components/modules/ToadCount.tsx
@@ -81,7 +81,7 @@ export default function ToadCount(props: { tripDbDoc: DocumentSnapshot | null, t
                 </div>
 
                 {/* Member List */}
-                <div className="mt-4 h-[150px] overflow-y-auto scrollbar-none space-y-3">
+                <div className="mt-4 h-[135px] overflow-y-auto scrollbar-none space-y-3">
                     {/* Can add members to the trip by calling <ToadMembers name="name" /> */}
                     {turnListOfTripsMembersIntoElems()}
                 </div>

--- a/app/components/modules/ToadCount/ToadMember.tsx
+++ b/app/components/modules/ToadCount/ToadMember.tsx
@@ -22,25 +22,26 @@ export default function ToadMember(props: { memberColor: string, tripDbDoc: Docu
         ;
 
     return (
-        <div className="relative w-[148px] h-[28px] bg-[#8FA789]/40 rounded-lg shadow-sm">
-            {/* Circle representing the color icon */}
-            <div
-                className={`w-[18.86px] h-[18.86px] rounded-full absolute left-[8px] top-1/2 transform -translate-y-1/2 ${props.memberColor}`}
-            ></div>
+        <div className = "flex flex-row  w-full">
+            <div className={`relative ${props.isTripOwner ? 'w-10/12' : 'w-full'} items-center h-[28px] bg-[#8FA789]/40 rounded-lg shadow-sm`}>
+                {/* Circle representing the color icon */}
+                <div
+                    className={`w-[18.86px] h-[18.86px] rounded-full absolute left-[8px] top-1/2 transform -translate-y-1/2 ${props.memberColor}`}
+                ></div>
 
-            {/* Name (wrapped inside overflow-hidden div) */}
-            <div className="absolute left-[45px] right-0 pr-2 h-full overflow-hidden whitespace-nowrap text-ellipsis">
-                <span className="text-[#3C533A] font-sunflower text-sm leading-[30px]">
-                    {memberName}
-                </span>
+                {/* Name (wrapped inside overflow-hidden div) */}
+                <div className="absolute left-[45px] right-2 h-full overflow-hidden whitespace-nowrap text-ellipsis">
+                    <span className="text-[#3C533A] font-sunflower text-sm leading-[30px]">
+                        {memberName}
+                    </span>
+                </div>
             </div>
-
             {/* Delete Button */}
             {props.isTripOwner && (<button
                 onClick={handleRemoveMember}
-                className="absolute left-[160px] w-[28px] h-[26px] top-1/2 transform -translate-y-1/2 bg-[#EACBAC] rounded-lg flex items-center justify-center hover:bg-[#EACBAC]/80"
+                className="w-[28px] h-[26px] ml-auto bg-[#EACBAC] rounded-lg flex items-center justify-center hover:bg-[#EACBAC]/80"
             >
-                <div className="absolute w-[16px] h-[0px] border border-white"></div>
+                <div className="w-[16px] h-[0px] border border-white"></div>
             </button>)}
         </div>
     );

--- a/app/components/modules/ToadCount/ToadMember.tsx
+++ b/app/components/modules/ToadCount/ToadMember.tsx
@@ -3,7 +3,8 @@ import React from "react";
 import { dbRemoveUserFromTrip } from "~/src/databaseUtil";
 import { debugLogComponentRerender, debugLogError } from "~/src/debugUtil";
 
-export default function ToadMember(props: { memberColor: string, tripDbDoc: DocumentSnapshot | null, memberDbDoc: DocumentSnapshot | null }) {
+
+export default function ToadMember(props: { memberColor: string, tripDbDoc: DocumentSnapshot | null, memberDbDoc: DocumentSnapshot | null, isTripOwner: boolean}) {
 
     debugLogComponentRerender("ToadMember");
 
@@ -28,19 +29,19 @@ export default function ToadMember(props: { memberColor: string, tripDbDoc: Docu
             ></div>
 
             {/* Name (wrapped inside overflow-hidden div) */}
-            <div className="absolute left-[45px] right-0 h-full overflow-hidden whitespace-nowrap text-ellipsis">
+            <div className="absolute left-[45px] right-0 pr-2 h-full overflow-hidden whitespace-nowrap text-ellipsis">
                 <span className="text-[#3C533A] font-sunflower text-sm leading-[30px]">
                     {memberName}
                 </span>
             </div>
 
             {/* Delete Button */}
-            <button
+            {props.isTripOwner && (<button
                 onClick={handleRemoveMember}
                 className="absolute left-[160px] w-[28px] h-[26px] top-1/2 transform -translate-y-1/2 bg-[#EACBAC] rounded-lg flex items-center justify-center hover:bg-[#EACBAC]/80"
             >
                 <div className="absolute w-[16px] h-[0px] border border-white"></div>
-            </button>
+            </button>)}
         </div>
     );
 };

--- a/app/components/modules/TripPageExpenses/ExpenseList.tsx
+++ b/app/components/modules/TripPageExpenses/ExpenseList.tsx
@@ -51,7 +51,7 @@ export default function ExpenseList(props: { view: "all" | "owe" | "owed", filte
                             props.expenses.map((expenseId: string) => {
                                 if (props.tripDbDoc !== null) {
                                     return (
-                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId}></Expense>
+                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId} currUser={props.currentUser}></Expense>
                                     );
                                 } else {
                                     return null;
@@ -79,7 +79,7 @@ export default function ExpenseList(props: { view: "all" | "owe" | "owed", filte
                             all_paid.map((expenseId: string) => {
                                 if (props.tripDbDoc !== null) {
                                     return (
-                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId}></Expense>
+                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId} currUser={props.currentUser}></Expense>
                                     );
                                 } else {
                                     return null;
@@ -107,7 +107,7 @@ export default function ExpenseList(props: { view: "all" | "owe" | "owed", filte
                             all_unpaid.map((expenseId: string) => {
                                 if (props.tripDbDoc !== null) {
                                     return (
-                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId}></Expense>
+                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId} currUser={props.currentUser}></Expense>
                                     );
                                 } else {
                                     return null;
@@ -149,7 +149,7 @@ export default function ExpenseList(props: { view: "all" | "owe" | "owed", filte
                             props.iOwePeople.map((expenseId: string) => {
                                 if (props.tripDbDoc !== null) {
                                     return (
-                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId}></Expense>
+                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId} currUser={props.currentUser}></Expense>
                                     );
                                 } else {
                                     return null;
@@ -177,7 +177,7 @@ export default function ExpenseList(props: { view: "all" | "owe" | "owed", filte
                             owe_paid.map((expenseId: string) => {
                                 if (props.tripDbDoc !== null) {
                                     return (
-                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId}></Expense>
+                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId} currUser={props.currentUser}></Expense>
                                     );
                                 } else {
                                     return null;
@@ -205,7 +205,7 @@ export default function ExpenseList(props: { view: "all" | "owe" | "owed", filte
                             owe_unpaid.map((expenseId: string) => {
                                 if (props.tripDbDoc !== null) {
                                     return (
-                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId}></Expense>
+                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId} currUser={props.currentUser}></Expense>
                                     );
                                 } else {
                                     return null;
@@ -256,7 +256,7 @@ export default function ExpenseList(props: { view: "all" | "owe" | "owed", filte
                             props.peopleOweMe.map((expenseId: string) => {
                                 if (props.tripDbDoc !== null) {
                                     return (
-                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId}></Expense>
+                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId} currUser={props.currentUser}></Expense>
                                     );
                                 } else {
                                     return null;
@@ -284,7 +284,7 @@ export default function ExpenseList(props: { view: "all" | "owe" | "owed", filte
                             owed_paid.map((expenseId: string) => {
                                 if (props.tripDbDoc !== null) {
                                     return (
-                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId}></Expense>
+                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId} currUser={props.currentUser}></Expense>
                                     );
                                 } else {
                                     return null;
@@ -312,7 +312,7 @@ export default function ExpenseList(props: { view: "all" | "owe" | "owed", filte
                             owed_unpaid.map((expenseId: string) => {
                                 if (props.tripDbDoc !== null) {
                                     return (
-                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId}></Expense>
+                                        <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId} currUser={props.currentUser}></Expense>
                                     );
                                 } else {
                                     return null;

--- a/app/components/modules/TripPageExpenses/ExpenseList/Expense.tsx
+++ b/app/components/modules/TripPageExpenses/ExpenseList/Expense.tsx
@@ -12,7 +12,7 @@ const months = [
     "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
 ];
 
-export default function Expense(props: { tripDbDoc: DocumentSnapshot, tripMembersInfo: TripMembersInfo, expenseId: string }) {
+export default function Expense(props: { tripDbDoc: DocumentSnapshot, tripMembersInfo: TripMembersInfo, expenseId: string, currUser: string}) {
 
     const expenseObj: any = props.tripDbDoc.get("expenses")[props.expenseId];
 
@@ -95,9 +95,9 @@ export default function Expense(props: { tripDbDoc: DocumentSnapshot, tripMember
             <div className="flex flex-row justify-between items-end pl-12">
                 {turnPayersDbDocsIntoElems()}
 
-                <button onClick={handleDeleteButton} className="bg-[#D86D6D]/70 hover:bg-[#D86D6D]/80 flex justify-center items-center px-5 py-1 rounded-lg">
+                {expenseOwnerInfo.dbDoc.get("email") === props.currUser ? <button onClick={handleDeleteButton} className="bg-[#D86D6D]/70 hover:bg-[#D86D6D]/80 flex justify-center items-center px-5 py-1 rounded-lg">
                     <span className="font-sunflower text-base text-white">Delete Expense</span>
-                </button>
+                </button>: null}
             </div>
         </div>
     );

--- a/app/components/modules/TripPageExpenses/MemberBreakdown.tsx
+++ b/app/components/modules/TripPageExpenses/MemberBreakdown.tsx
@@ -77,10 +77,10 @@ export default function MemberBreakdown(props: {memberEmail: string, memberFirst
         // Blacking out the whole page
         <div className="fixed inset-0 flex justify-center items-center bg-black bg-opacity-50 z-50" onClick={handleOverlayClick}>
             {/* Modal itself */}
-            <div ref={modalContentRef} className="relative flex flex-col w-2/3 justify-center items-center bg-dashboard_component_bg py-8 rounded-2xl px-8 mx-4" onClick={(e) => e.stopPropagation()}>
+            <div ref={modalContentRef} className="relative flex flex-col w-2/3 justify-center items-center bg-dashboard_component_bg py-6 rounded-2xl px-6 mx-4" onClick={(e) => e.stopPropagation()}>
                 
                 {/* Total Owed Amounts */}
-                <div className="flex flex-col justify-center w-full gap-y-4 -mt-4">
+                <div className="flex flex-col justify-center w-full gap-y-4">
                     <div className="flex flex-row justify-center w-full">
                         <div className="flex w-1/2  bg-[#D7F297] p-2 rounded-xl mr-2 items-center justify-center">
                             <p className="font-sunflower text-2xl text-sidebar_deep_green">

--- a/app/components/modules/TripPageExpenses/MemberBreakdown.tsx
+++ b/app/components/modules/TripPageExpenses/MemberBreakdown.tsx
@@ -63,7 +63,7 @@ export default function MemberBreakdown(props: {memberEmail: string, memberFirst
                 theyOweList.map((expenseId: string) => {
                     if (props.tripDbDoc !== null) {
                         return (
-                            <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId}></Expense>
+                            <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId} currUser={props.currUser}></Expense>
                         );
                     } else {
                         return null;

--- a/app/components/modules/TripPageExpenses/MemberBreakdown.tsx
+++ b/app/components/modules/TripPageExpenses/MemberBreakdown.tsx
@@ -47,7 +47,7 @@ export default function MemberBreakdown(props: {memberEmail: string, memberFirst
                 iOweList.map((expenseId: string) => {
                     if (props.tripDbDoc !== null) {
                         return (
-                            <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId}></Expense>
+                            <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId} currUser={props.currUser}></Expense>
                         );
                     } else {
                         return null;

--- a/app/components/modules/TripPageExpenses/MemberBreakdown.tsx
+++ b/app/components/modules/TripPageExpenses/MemberBreakdown.tsx
@@ -1,0 +1,134 @@
+import type { DocumentSnapshot } from "firebase/firestore";
+import React from "react";
+import { useRef, useState } from 'react';
+import type { TripMembersInfo } from "~/components/pages/TripPageLayout";
+import Expense from "../../modules/TripPageExpenses/ExpenseList/Expense"
+export default function MemberBreakdown(props: {memberEmail: string, memberFirstName: string, iOwePeople: string[], peopleOweMe: string[], currUser: string, expensesDict: any, tripMembersInfo: TripMembersInfo,  tripDbDoc: DocumentSnapshot | null, onClose: () => void}) {
+
+    const modalContentRef = useRef<HTMLDivElement>(null);
+    const [view, setView] = useState<"owe" | "owed">("owe");
+
+    const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+            if (modalContentRef.current && !modalContentRef.current.contains(e.target as Node)) {
+                props.onClose();
+            }
+    };
+
+    let iOwe:number = 0;
+    let theyOwe:number = 0;
+    let iOwePaid:number = 0;
+    let theyOwePaid:number = 0;
+    let iOweList:string[] = [];
+    let theyOweList: string[] = [];
+    for(const expense of props.iOwePeople) {
+        if(props.expensesDict[expense]["expense_owner"] === props.memberEmail) {
+            if(props.expensesDict[expense]["payers"][props.currUser][1] == 0) {
+                iOwe += props.expensesDict[expense]["payers"][props.currUser][0];
+            } else {
+                iOwePaid += props.expensesDict[expense]["payers"][props.currUser][0];
+            }
+            iOweList.push(expense);
+        }
+    }
+    for(const expense of props.peopleOweMe) {
+        if(props.memberEmail in props.expensesDict[expense]["payers"]) {
+            if(props.expensesDict[expense]["payers"][props.memberEmail][1] == 0) {
+                theyOwe += props.expensesDict[expense]["payers"][props.memberEmail][0];
+            } else {
+                theyOwePaid += props.expensesDict[expense]["payers"][props.memberEmail][0];
+            }
+            theyOweList.push(expense);
+        }
+    }
+
+    const iOweView = () => {
+        return(<div className="flex flex-col gap-3 m-3" >
+            {
+                iOweList.map((expenseId: string) => {
+                    if (props.tripDbDoc !== null) {
+                        return (
+                            <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId}></Expense>
+                        );
+                    } else {
+                        return null;
+                    }
+                })
+            }
+        </div>);
+    }
+
+    const theyOweView = () => {
+        return(<div className="flex flex-col gap-3 m-3">
+            {
+                theyOweList.map((expenseId: string) => {
+                    if (props.tripDbDoc !== null) {
+                        return (
+                            <Expense key={expenseId} tripDbDoc={props.tripDbDoc} tripMembersInfo={props.tripMembersInfo} expenseId={expenseId}></Expense>
+                        );
+                    } else {
+                        return null;
+                    }
+                })
+            }
+        </div>);
+    }
+
+    return(
+        // Blacking out the whole page
+        <div className="fixed inset-0 flex justify-center items-center bg-black bg-opacity-50 z-50" onClick={handleOverlayClick}>
+            {/* Modal itself */}
+            <div ref={modalContentRef} className="relative flex flex-col w-2/3 justify-center items-center bg-dashboard_component_bg py-8 rounded-2xl px-8 mx-4" onClick={(e) => e.stopPropagation()}>
+                
+                {/* Total Owed Amounts */}
+                <div className="flex flex-col justify-center w-full gap-y-4 -mt-4">
+                    <div className="flex flex-row justify-center w-full">
+                        <div className="flex w-1/2  bg-[#D7F297] p-2 rounded-xl mr-2 items-center justify-center">
+                            <p className="font-sunflower text-2xl text-sidebar_deep_green">
+                                    <b>You Owe {" "}{props.memberFirstName}{" "}</b>
+                                    <span className="text-red-800">${iOwe.toFixed(2)}</span>
+                            </p>
+                        </div>
+                        <div className="flex w-1/2  bg-[#D7F297] p-2 rounded-xl ml-2 justify-center items-center">
+                            <p className="font-sunflower text-2xl text-sidebar_deep_green">
+                                    <b>{props.memberFirstName}{" "}Owes You{" "}</b>
+                                    <span className="text-red-800">${theyOwe.toFixed(2)}</span>
+                            </p>
+                        </div>
+                    </div>
+                    <div className="flex flex-row justify-center w-full">
+                        <div className="flex w-1/2  bg-[#D7F297] p-2 rounded-xl mr-2 items-center justify-center">
+                            <p className="font-sunflower text-2xl text-sidebar_deep_green">
+                                    <b>You have paid {" "}{props.memberFirstName}{" "}</b>
+                                    <span className="text-red-800">${iOwePaid.toFixed(2)}</span>
+                            </p>
+                        </div>
+                        <div className="flex w-1/2  bg-[#D7F297] p-2 rounded-xl ml-2 justify-center items-center">
+                            <p className="font-sunflower text-2xl text-sidebar_deep_green">
+                                    <b>{props.memberFirstName}{" "}Has Paid You{" "}</b>
+                                    <span className="text-red-800">${theyOwePaid.toFixed(2)}</span>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                {/* Background Decoration */}
+                <div className="flex flex-col bg-[#D7F297] w-full mt-4 rounded-2xl h-96">
+                    {/* Sorting Buttons */}
+                    <div className="flex flex-row justify-center pt-0 max-h-9">
+                        <div className="w-1/2 h-18">
+                            <button onClick={() => setView("owe")} className={`w-full h-9 rounded-tl-2xl font-sunflower text-sidebar_deep_green text-xl hover:ring-[#FFF]/40 hover:ring-2 ${view === "owe" ? "bg-sidebar_deep_green/25" : "bg-sidebar_deep_green/10"} hover:bg-sidebar_deep_green/25`}>I Owe</button>
+                        </div>
+                        <div className="w-1/2 h-18">
+                            <button onClick={() => setView("owed")} className={`w-full h-9 rounded-tr-2xl font-sunflower text-sidebar_deep_green text-xl hover:ring-[#FFF]/40 hover:ring-2 ${view === "owed" ? "bg-sidebar_deep_green/25" : "bg-sidebar_deep_green/10"} hover:bg-sidebar_deep_green/25`}>Owes Me</button>
+                        </div>
+                    </div>
+                    <div className="overflow-auto scrollbar-thin flex flex-col gap-3 m-3">
+                        {view == "owe" ? iOweView(): theyOweView()}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+
+
+
+}

--- a/app/components/modules/TripPageExpenses/NewExpense/NewExpenseStepOne.tsx
+++ b/app/components/modules/TripPageExpenses/NewExpense/NewExpenseStepOne.tsx
@@ -3,8 +3,11 @@ import React from "react";
 import AddMemberToExpense from "/AddMemberToExpense.svg";
 import DeleteMemberFromExpense from "/DeleteMemberFromExpense.svg";
 import type { TripMembersInfo } from "~/components/pages/TripPageLayout";
-
+import { useTripPageLayoutContext, type TripPageLayoutContext } from "../../../pages/TripPageLayout";
 export default function NewExpenseStepOne({ tripMembersInfo, payees, setPayees }: { tripMembersInfo: TripMembersInfo, payees: { [key: string]: number[] }, setPayees: React.Dispatch<React.SetStateAction<{ [key: string]: number[] }>> }) {
+
+    const tripPageLayoutContext: TripPageLayoutContext = useTripPageLayoutContext();
+    const active_users: string[] = tripPageLayoutContext.tripDbDoc.get("trip_active_users");
 
     //adds members to expense if the add button is clicked
     const HandleAddMember = (member: DocumentSnapshot) => {
@@ -78,7 +81,7 @@ export default function NewExpenseStepOne({ tripMembersInfo, payees, setPayees }
     //lists out all the members in the trip that are not yet added to an expense
     const renderMemberBoxes = () => {
         return Object.keys(tripMembersInfo).map(memberId => {
-            if (Object.hasOwn(payees, memberId)) return null;
+            if (Object.hasOwn(payees, memberId) || !(active_users).includes(memberId)) return null;
             return <MemberBox key={memberId} member={tripMembersInfo[memberId].dbDoc} />;
         });
     };

--- a/app/components/modules/TripPageExpenses/NewExpense/NewExpenseStepOne.tsx
+++ b/app/components/modules/TripPageExpenses/NewExpense/NewExpenseStepOne.tsx
@@ -35,7 +35,7 @@ export default function NewExpenseStepOne({ tripMembersInfo, payees, setPayees }
         return (
             <div className="relative w-[148px] h-[28px] bg-[#ABC893] rounded-lg shadow-sm">
                 <div className={`w-[18.86px] h-[18.86px] rounded-full absolute left-[8px] top-1/2 transform -translate-y-1/2 ${userColor}`}></div>
-                <div className="absolute left-[45px] right-0 h-full overflow-hidden whitespace-nowrap text-ellipsis">
+                <div className="absolute left-[45px] right-2 h-full overflow-hidden whitespace-nowrap text-ellipsis">
                     <span className="text-[#3C533A] font-sunflower text-sm leading-[30px]">
                         {memberName}
                     </span>
@@ -59,7 +59,7 @@ export default function NewExpenseStepOne({ tripMembersInfo, payees, setPayees }
         return (
             <div className="relative w-[148px] h-[28px] bg-[#8FA789]/40 rounded-lg shadow-sm">
                 <div className={`w-[18.86px] h-[18.86px] rounded-full absolute left-[8px] top-1/2 transform -translate-y-1/2 ${userColor}`}></div>
-                <div className="absolute left-[45px] right-0 h-full overflow-hidden whitespace-nowrap text-ellipsis">
+                <div className="absolute left-[45px] right-2 h-full overflow-hidden whitespace-nowrap text-ellipsis">
                     <span className="text-[#3C533A] font-sunflower text-sm leading-[30px]">
                         {memberName}
                     </span>
@@ -96,7 +96,7 @@ export default function NewExpenseStepOne({ tripMembersInfo, payees, setPayees }
     return (
         <div className="w-[236px] h-[300px] bg-[#BDDE9A] p-6 pb-10 rounded-lg shadow-lg space-y-4">
             <div className="flex justify-center -mt-4">
-                <div className="w-[217px] min-w-[217px] max-w-[217px] h-[55px] p-2 overflow-y-auto scrollbar-none space-y-3 bg-[#8FAE72] rounded-lg">
+                <div className="w-[217px] min-w-[217px] max-w-[217px] h-[100px] p-2 overflow-y-auto scrollbar-none space-y-3 bg-[#8FAE72] rounded-lg">
                     {renderAddedMembers()}
                 </div>
             </div>

--- a/app/components/modules/TripPageExpenses/NewExpense/NewExpenseStepTwo.tsx
+++ b/app/components/modules/TripPageExpenses/NewExpense/NewExpenseStepTwo.tsx
@@ -137,7 +137,7 @@ export default function NewExpenseStepTwo({ tripMembersInfo, totalCost, payees, 
             {/* Specify Expenses Big Box */}
             {/* <div> */}
             <div className=" w-4/5 h-44 bg-[#BDDE9A] rounded-lg p-4">
-                <div className="flex flex-col gap-2 overflow-scroll h-full">
+                <div className="flex flex-col gap-2 overflow-scroll overflow-x-hidden h-full scrollbar-thin scrollbar-track-transparent scrollbar-thumb-sidebar_button_bg">
                     {Object.keys(payees).map((item) => (
                         <div key={item} className="flex justify-between">
                             <NameCard name={item} />

--- a/app/components/modules/TripPagePlan/DestinationBox.tsx
+++ b/app/components/modules/TripPagePlan/DestinationBox.tsx
@@ -35,9 +35,9 @@ export default function DestinationBox(props: { tripDbDoc: DocumentSnapshot, des
 
                 <div className="flex flex-wrap justify-end gap-1" onPointerDown={(e) => e.stopPropagation()}>
                     {/* Edit Button */}
-                    <button className="w-6 h-6" aria-label="Edit destination">
+                    {/* <button className="w-6 h-6" aria-label="Edit destination">
                         <img src={EditBox} alt="Edit Box" />
-                    </button>
+                    </button> */}
 
                     {/*Trash Button*/}
                     <button onClick={() => handleDelete(props.destinationId)} className="w-6 h-6" aria-label="Delete destination">

--- a/app/components/modules/TripPagePlan/Itinerary/CalendarCard.tsx
+++ b/app/components/modules/TripPagePlan/Itinerary/CalendarCard.tsx
@@ -5,6 +5,16 @@ import { useParams } from "react-router";
 import stayAtIcon from "/stayAt.svg"
 import { DestinationDroppable, SortableDestinationBox } from "~/components/pages/TripPagePlan";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import linkifyHtml from "linkify-html";
+
+const options = {
+    defaultProtocol: "https",
+    attributes: {
+      target: "_blank",
+      rel: "noopener noreferrer",
+      contentEditable: "false"
+    }
+  };
 
 // CalendarCard creates SINGULAR itinerary card representing a single day
 
@@ -94,11 +104,26 @@ export default function CalendarCard(props: { dbIndex: number, activities: any[]
                 }
 
                 if (stayAtRef.current && updatedStayAt) {
-                    stayAtRef.current.innerText = updatedStayAt;
+                    stayAtRef.current.innerHTML = linkifyHtml(updatedStayAt, options);
                 }
             }
         }
     }, [props.tripDbDoc]);
+
+    useEffect(() =>{
+        const currentStayAt = stayAtRef.current;
+        if(currentStayAt) {
+            const clickHandler = (e: MouseEvent) => {
+                const target = e.target as HTMLElement;
+                if (target.tagName === "A") {
+                    window.open((target as HTMLAnchorElement).href, "_blank");
+                    e.preventDefault();
+                }
+            };
+            currentStayAt.addEventListener("click", clickHandler);
+            return () => currentStayAt.removeEventListener("click", clickHandler);
+        }
+    }, []);
 
     function turnActivitiesIntoElems(activities: any[]): ReactNode {
         return (

--- a/app/components/pages/CreateTrip.tsx
+++ b/app/components/pages/CreateTrip.tsx
@@ -19,10 +19,20 @@ export default function CreateTrip() {
     const [tripName, setTripName] = useState('');
     const [startDate, setStartDate] = useState('');
     const [endDate, setEndDate] = useState('');
+     const [error, setError] = useState('');
 
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         try {
+
+            if (new Date(endDate) < new Date(startDate)) {
+                setError("Please make sure that your start date is before your end date!");
+                setTripName('');
+                setStartDate('');
+                setEndDate('');
+                throw new Error("bad request");
+            }
+
             const tripDbDocRef = await dbCreateTrip(tripName, startDate, endDate, mainLayoutContext.userDbDoc.get("email"));
 
             setTripName('');
@@ -31,7 +41,7 @@ export default function CreateTrip() {
 
             navigate(`/trip/${tripDbDocRef.id}`);
         }
-        catch (error) {
+        catch (err:any) {
             console.error("Error adding trip: ", error);
         }
     };
@@ -99,6 +109,7 @@ export default function CreateTrip() {
                         >
                             Begin
                         </button>
+                        <p className="font-maven text-red-900 width-2 text-center">{error}</p>
                     </form>
                 </div>
             </div>

--- a/app/components/pages/TripPageExpenses.tsx
+++ b/app/components/pages/TripPageExpenses.tsx
@@ -82,7 +82,7 @@ export default function BudgetPageMain() {
         return (
             <div 
                 onClick={() => onClick(member)}
-                className="relative w-[148px] h-[28px] bg-[#8FA789]/40 rounded-lg shadow-sm"
+                className="relative w-full h-[28px] bg-[#8FA789]/40 rounded-lg shadow-sm"
             >
                 <div className={`w-[18.86px] h-[18.86px] rounded-full absolute left-[8px] top-1/2 transform -translate-y-1/2 ${userColor}`}></div>
                 <div className="absolute left-[45px] right-2 h-full overflow-hidden whitespace-nowrap text-ellipsis">
@@ -97,11 +97,11 @@ export default function BudgetPageMain() {
 
     const renderAllMembers = () => {
         return (
-            <div className="flex flex-col bg-[#EAFFB9] p-3 rounded-2xl">
+            <div className="flex flex-col bg-[#EAFFB9] p-3 rounded-xl">
                 <div className="flex flex-col  overflow-auto items-center justify-center bg-sidebar_deep_green font-sunflower text-white text-l rounded-lg p-1">
                     <p>View Expenses By Person</p>
                 </div>
-                <div className="flex flex-col gap-3 m-3">
+                <div className="flex flex-col gap-3 mt-3">
                 {
                     users_list.map((memberEmail: string) => {
                         if (tripPageLayoutContext.tripDbDoc !== null && memberEmail !== currUser) {
@@ -181,19 +181,19 @@ export default function BudgetPageMain() {
                 {/* Sidebar Div */}
                 <div className="flex flex-col w-1/5 h-full gap-y-4">
                     <div className="bg-[#D7F297] p-5 rounded-xl">
-                        <p className="font-sunflower text-2xl text-sidebar_deep_green">
+                        <p className="font-sunflower text-xl text-sidebar_deep_green">
                             <b>You owe all toads on board </b>
                             <span className="text-red-800">${i_owe_toads.toFixed(2)}</span>
                         </p>
                     </div>
                     <div className="bg-[#D7F297] p-5 rounded-xl">
-                        <p className="font-sunflower text-2xl text-sidebar_deep_green">
+                        <p className="font-sunflower text-xl text-sidebar_deep_green">
                             <b>All toads owe you </b>
                             <span className="text-red-800">${toads_owe_me.toFixed(2)}</span>
                         </p>
                     </div>
                     <div className="bg-[#D7F297] p-5 rounded-xl">
-                        <p className="font-sunflower text-2xl text-sidebar_deep_green">
+                        <p className="font-sunflower text-xl text-sidebar_deep_green">
                             <b>All toads have paid you </b>
                             <span className="text-red-800">${toads_paid_me.toFixed(2)}</span>
                         </p>

--- a/app/components/pages/TripPageExpenses.tsx
+++ b/app/components/pages/TripPageExpenses.tsx
@@ -71,14 +71,14 @@ export default function BudgetPageMain() {
     const [isModalOpen, setIsModalOpen] = useState(false);
 
     return (
-        <div className="grow flex flex-col gap-5 bg-dashboard_lime">
+        <div className="grow flex flex-col flex-auto gap-5 overflow-auto scrollbar-thin scrollbar-thumb-sidebar_deep_green scrollbar-track-transparent bg-dashboard_lime">
             {/* Non button div */}
             <div className="mt-[3px]">
                 <Link to="./.." className="bg-dashboard_component_bg py-2 px-4 rounded-lg font-sunflower text-sidebar_deep_green underline">Back</Link>
             </div>
-            <div className="flex flex-row gap-5 h-full">
+            <div className="flex flex-row gap-5">
                 {/* Main Div */}
-                <div className="grow flex flex-col w-4/5 gap-5 justify-between">
+                <div className="grow flex flex-col overflow-auto w-4/5 gap-5 justify-between">
                     <div className="bg-[#D7F297] h-full rounded-xl">
                         {/* Buttons to Sort */}
                         <div className="flex flex-row justify-center -mt-2 w-full max-h-18">

--- a/app/components/pages/TripPageExpenses.tsx
+++ b/app/components/pages/TripPageExpenses.tsx
@@ -97,7 +97,11 @@ export default function BudgetPageMain() {
 
     const renderAllMembers = () => {
         return (
-            <div className="flex flex-col gap-3 m-3">
+            <div className="flex flex-col bg-[#EAFFB9] p-3 rounded-2xl">
+                <div className="flex flex-col  overflow-auto items-center justify-center bg-sidebar_deep_green font-sunflower text-white text-l rounded-lg p-1">
+                    <p>View Expenses By Person</p>
+                </div>
+                <div className="flex flex-col gap-3 m-3">
                 {
                     users_list.map((memberEmail: string) => {
                         if (tripPageLayoutContext.tripDbDoc !== null && memberEmail !== currUser) {
@@ -113,6 +117,7 @@ export default function BudgetPageMain() {
                         }
                     })
                 }
+                </div>
             </div>
         );
     };

--- a/app/components/pages/TripPageExpenses.tsx
+++ b/app/components/pages/TripPageExpenses.tsx
@@ -21,7 +21,8 @@ export default function BudgetPageMain() {
 
     const currUser: string = tripPageLayoutContext.userDbDoc.get("email");
     const expenses = tripPageLayoutContext.tripDbDoc.get("expenses");
-    const users_list = tripPageLayoutContext.tripDbDoc.get("trip_users");
+    const users_list = tripPageLayoutContext.tripDbDoc.get("trip_active_users");
+    const users_archived_list = tripPageLayoutContext.tripDbDoc.get("trip_users");
     const expenses_sorted: string[] = Object.keys(expenses).sort((a, b) => {
         const dateA: number = new Date(expenses[a].date).getTime();
         const dateB: number = new Date(expenses[b].date).getTime();
@@ -82,7 +83,7 @@ export default function BudgetPageMain() {
         return (
             <div 
                 onClick={() => onClick(member)}
-                className="relative w-full h-[28px] bg-[#8FA789]/40 rounded-lg shadow-sm"
+                className="relative w-full h-[28px] bg-[#8FA789]/40 shadow-sm rounded-lg"
             >
                 <div className={`w-[18.86px] h-[18.86px] rounded-full absolute left-[8px] top-1/2 transform -translate-y-1/2 ${userColor}`}></div>
                 <div className="absolute left-[45px] right-2 h-full overflow-hidden whitespace-nowrap text-ellipsis">
@@ -97,13 +98,13 @@ export default function BudgetPageMain() {
 
     const renderAllMembers = () => {
         return (
-            <div className="flex flex-col bg-[#EAFFB9] p-3 rounded-xl">
-                <div className="flex flex-col  overflow-auto items-center justify-center bg-sidebar_deep_green font-sunflower text-white text-l rounded-lg p-1">
+            <div className="flex flex-col bg-[#EAFFB9] rounded-xl">
+                <div className="flex flex-col  overflow-auto items-center justify-center text-sidebar_deep_green text-l rounded-tl-xl rounded-tr-xl p-1">
                     <p>View Expenses By Person</p>
                 </div>
-                <div className="flex flex-col gap-3 mt-3">
+                <div className="flex flex-col mx-2  my-3 gap-2">
                 {
-                    users_list.map((memberEmail: string) => {
+                    users_archived_list.map((memberEmail: string) => {
                         if (tripPageLayoutContext.tripDbDoc !== null && memberEmail !== currUser) {
                             return (
                                 <MemberBox 
@@ -198,8 +199,8 @@ export default function BudgetPageMain() {
                             <span className="text-red-800">${toads_paid_me.toFixed(2)}</span>
                         </p>
                     </div>
-                    <button onClick={() => setIsModalOpen(true)} className="bg-sidebar_deep_green rounded-xl p-2 font-sunflower text-white text-2xl">
-                        Add an Expense
+                    <button onClick={() => setIsModalOpen(true)} className="bg-sidebar_deep_green rounded-xl p-1 font-sunflower text-white text-2xl">
+                        + Add an Expense
                     </button>
 
                     {

--- a/app/components/pages/TripPageMain.tsx
+++ b/app/components/pages/TripPageMain.tsx
@@ -9,6 +9,15 @@ export default function TripPageMain() {
     debugLogComponentRerender("TripPageMain");
 
     const tripPageLayoutContext: TripPageLayoutContext = useTripPageLayoutContext();
+    const currUser: string = tripPageLayoutContext.userDbDoc.get("email");
+
+    if(!(tripPageLayoutContext.tripDbDoc.get("trip_users").includes(currUser))) {
+        return(
+            <div className="flex w-full align-middle justify-center items-center font-sunflower text-4xl text-sidebar_deep_green">
+                <text>Forbidden! You are not a part of this trip.</text>
+            </div>
+        );
+    }
 
     const tripName: string = tripPageLayoutContext.tripDbDoc.get("trip_name");
 

--- a/app/components/pages/TripPageMain.tsx
+++ b/app/components/pages/TripPageMain.tsx
@@ -11,7 +11,7 @@ export default function TripPageMain() {
     const tripPageLayoutContext: TripPageLayoutContext = useTripPageLayoutContext();
     const currUser: string = tripPageLayoutContext.userDbDoc.get("email");
 
-    if(!(tripPageLayoutContext.tripDbDoc.get("trip_users").includes(currUser))) {
+    if(!(tripPageLayoutContext.tripDbDoc.get("trip_active_users").includes(currUser))) {
         return(
             <div className="flex w-full align-middle justify-center items-center font-sunflower text-4xl text-sidebar_deep_green">
                 <text>Forbidden! You are not a part of this trip.</text>

--- a/app/src/databaseUtil.ts
+++ b/app/src/databaseUtil.ts
@@ -113,6 +113,7 @@ export async function dbCreateTrip(tripName: string, startDate: string, endDate:
         trip_owner: tripOwner,
         days: num_days,
         trip_users: [],
+        trip_active_users: [],
         itinerary: itin,
         destinations: {},
         expenses: {}
@@ -192,7 +193,8 @@ export async function dbDeclineInvitation(userDbDoc: DocumentSnapshot, tripId: s
 
 export async function dbAddUserToTrip(tripDbDocRef: DocumentReference, userDbDoc: DocumentSnapshot) {
     await updateDoc(tripDbDocRef, {
-        trip_users: arrayUnion(userDbDoc.id)
+        trip_users: arrayUnion(userDbDoc.id), 
+        trip_active_users: arrayUnion(userDbDoc.id)
     });
 
     await updateDoc(userDbDoc.ref, {
@@ -206,7 +208,7 @@ export async function dbRemoveUserFromTrip(tripDbDoc: DocumentSnapshot, userDbDo
     });
 
     await updateDoc(tripDbDoc.ref, {
-        trip_users: arrayRemove(userDbDoc.id)
+        trip_active_users: arrayRemove(userDbDoc.id)
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
 		"@svgr/webpack": "^8.1.0",
 		"firebase": "^11.2.0",
 		"isbot": "^5.1.17",
+		"linkify-html": "^4.2.0",
+		"linkifyjs": "^4.2.0",
 		"react": "^19.0.0",
 		"react-beautiful-dnd": "^13.1.1",
 		"react-dom": "^19.0.0",


### PR DESCRIPTION
Change Log:
- MAJOR database change; new field of trip_active_users is added which fixes a big with the expense page breaking if a deleted member was a part of an expense
- As a result of the above, changes made to database util, trip page layout, and a variety of other subpages that display trip members or require trip member information to render
- Aesthetic changes to toad count
- Only trip owner can delete trip
- Only trip owner can delete members from trip
- Only expense owner can delete an expense
- Trip end date before start date bug fixed
- Removed edit button on DestinationBox
- Links are now clickable on trip plan page; ADDED LINKIFYJS LIBRARY — will need to run npm install --legacy-peer-deps
- Member breakdown is added to the expense page. Member breakdown shows *all trip members*, not just active ones. Opens a modal that showcases what expenses you owe to that trip member and what they owe you. Signed in user is not included in the users list